### PR TITLE
Fix string replacement corruption on multibyte files

### DIFF
--- a/lib/be_let_it_be/converter.rb
+++ b/lib/be_let_it_be/converter.rb
@@ -26,8 +26,8 @@ module BeLetItBe
     def apply_single_conversion(let_info, source)
       node = let_info[:node]
 
-      start_offset = node.message_loc.start_offset
-      end_offset = node.message_loc.end_offset
+      start_offset = node.message_loc.start_character_offset
+      end_offset = node.message_loc.end_character_offset
 
       new_source = source.dup
       new_source[start_offset...end_offset] = "let_it_be"

--- a/test/test_converter.rb
+++ b/test/test_converter.rb
@@ -31,6 +31,31 @@ class TestConverter < Minitest::Test
     end
   end
 
+  def test_conversion_with_multibyte_characters_before_let
+    # Prism's offsets are byte-based; without start_character_offset,
+    # multibyte chars before `let` shift String#[]= indices and corrupt the replacement.
+    source = <<~RUBY
+      # 日本語コメント
+      RSpec.describe "Test" do
+        let(:value) { 42 }
+      end
+    RUBY
+
+    Tempfile.create("test_spec.rb") do |temp_file|
+      File.write(temp_file, source)
+
+      analyzer = BeLetItBe::Analyzer.new(temp_file)
+      lets = analyzer.find_lets
+      converter = BeLetItBe::Converter.new(temp_file)
+
+      converter.try_conversion_single_let(lets.first, temp_file, -> { true })
+
+      result = File.read(temp_file)
+      assert_includes result, "let_it_be(:value)", "multibyte characters before let must not corrupt the replacement position"
+      refute_includes result, "let(:value)"
+    end
+  end
+
   def test_apply_multiple_conversions
     source = <<~RUBY
       RSpec.describe "Test" do


### PR DESCRIPTION
Prism's start_offset / end_offset are byte positions, but Ruby's String#[]= interprets indices as character counts. When multibyte characters (e.g. Japanese) appear before `let`, the byte offset and character offset diverge and the replacement lands at the wrong position.

Prism's Location already provides start_character_offset / end_character_offset, so switching to these character-based offsets fixes the root cause without any encoding conversion gymnastics. A regression test is included.