### PR TITLE
Support Ruby 4 by adding `logger` package as a dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     be-let-it-be (0.0.4)
+      logger
       prism (~> 1.4)
       thor (~> 1.3)
 
@@ -22,6 +23,7 @@ GEM
     json (2.20.0)
     language_server-protocol (3.17.0.6)
     lint_roller (1.1.0)
+    logger (1.7.0)
     minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
@@ -112,4 +114,4 @@ DEPENDENCIES
   test-prof (~> 1.4)
 
 BUNDLED WITH
-   4.0.15
+  4.0.15

--- a/be_let_it_be.gemspec
+++ b/be_let_it_be.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |spec|
   spec.executables = ["be-let-it-be"]
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "logger"
   spec.add_dependency "prism", "~> 1.4"
   spec.add_dependency "thor", "~> 1.3"
 end


### PR DESCRIPTION
MEMO: Workaround for https://github.com/test-prof/test-prof/pull/346